### PR TITLE
Fix broken page headline

### DIFF
--- a/analysis/ROOT5-to-6.md
+++ b/analysis/ROOT5-to-6.md
@@ -1,4 +1,4 @@
- Transition from ROOT5 to ROOT6
+# Transition from ROOT5 to ROOT6
 
 *ROOT6* is similar to *ROOT5*: It comes with the same library of classes (base
 classes, histogram classes like TH1, ...) which share the same interface as under

--- a/analysis/bonus.md
+++ b/analysis/bonus.md
@@ -8,7 +8,9 @@ As you can see in the figure, the TPC signals of different particle species cros
 
 If you are very enthousiastic,
 
-*   try to estimate the _systematic uncertainty_ that particle identification introduces to your measurement# Make it presentable
+*   try to estimate the _systematic uncertainty_ that particle identification introduces to your measurement
+
+# Make it presentable
 
 By now, you have made quite a few nice plots. Modify the code such that the labels, titles, markers, colors, legends of your plots look decent and presentable for fellow colleagues
 


### PR DESCRIPTION
Page header was removed by mistake and therefore not highlighted in the current version