### PR TITLE
added two examples of adding arguments to function calls

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -1,7 +1,7 @@
 # Writing a *mini-analysis*
 
-In the following exercises, you will write a very small, but realistic, data analysis from the grounds up. The starting point is a minimal task that fills a histogram with a transverse momentum distribution. This task has already been written for you. As you go along, you will add code to this task, so that in the end, you can run a mini-analysis measuring the centrality dependence of charged pions production at mid-rapidity. 
+In the following exercises, you will write a very small, but realistic, data analysis from the ground up. The starting point is a minimal task that fills a histogram with a transverse momentum distribution. This task has already been written for you. As you go along, you will add code to this task, so that in the end, you can run a mini-analysis measuring the centrality dependence of charged pion production at mid-rapidity. 
 
-The exercises were originally used to accompany a set of lectures [that you can find here, (check the Thursday)](https://indico.cern.ch/event/666222/timetable/#20171102). However, you can be followed without having attended the lecture. 
+The exercises were originally used to accompany a set of lectures [that you can find here, (check the Thursday)](https://indico.cern.ch/event/666222/timetable/#20171102). However, they can be followed without having attended the lecture. 
 
 To access ALICE data and run the analysis on the Grid, you will need to be an ALICE member (a CERN lightweight account does not suffice). When in doubt about this, ask your supervisor.  

--- a/analysis/ROOT5-to-6.md
+++ b/analysis/ROOT5-to-6.md
@@ -103,7 +103,19 @@ most common use cases:
   Adding function arguments is possible here as well as a simple string
   representation after the macro path, surrounded with (). This method also works
   both under *ROOT5* and *ROOT6*.
+  
+  An example of adding function arguments using a TString literal (this method) is shown here. Suppose you
+  have a dummy AddTask file that takes a boolean and and a string as arguments. The way
+  to call this function would then be
+  
+  ```C++ 
+    TString arguments = R"((kTRUE, "test.root"))";
+    AliAnalysisTaskDummy *task = reinterpret_cast<AliAnalysisTaskDummy*>(gInterpreter->ProcessLine(".x AddTaskDummy.C" +  arguments));
+  ```
 
+  Note the syntax! The outer R"( and )" are part of the TString literal while the innner ( and ) 
+  are there for the function call of AddTaskDummmy.
+  
 - Including macros:
 
   As *ROOT6* compiles the macro it is possible to include macros and treat them
@@ -142,7 +154,31 @@ most common use cases:
   kTRUE to AddTaskPhysicsSelection) this method is very convenient. This method
   is specific to *ROOT6*. The part including macros has to be protected (see
   below).
-
+  
+  To include a macro that is not part of AliROOT or AliPhysics is a bit trickier but 
+  definitely possible. Such could be the case for a locally modified AddTask macro.
+  In this case you need to compile the macro first in an interactive session
+  
+  ```C++
+    aliroot
+    .L AddTaskDummy.C
+    exit
+  ```
+  This will generate a library file for ROOT to load. Now, in your run macro, you can add
+  the following to the preamble:
+  
+  ```C++
+    R__LOAD_LIBRARY(AliAnalysisTaskDummy_cxx.so)
+    #include "AddTaskDummy.C"
+  ```
+  
+  This will allow you to call the function directly in the body of your run macro, 
+  the same way you would as in ROOT5.
+  
+  ```C++
+    AliAnalysisTaskDummy *task = AddTaskDummy(kTRUE, "test.root");
+  ```
+  
 ## Do I need to include header files in my macros?
 
 *ROOT6* comes with a technique called pre-compiled header files. Header files

--- a/analysis/pid.md
+++ b/analysis/pid.md
@@ -53,7 +53,7 @@ After making changes to the header, you can add the actual identification routin
 
 *   Retrieve the AliPIDResponse object from the analysis manager;
 
-*   make our poiter ‘fPIDResponse’ point to the AliPIDResponse object;
+*   make our pointer ‘fPIDResponse’ point to the AliPIDResponse object;
 
 *   include the header for the AliPIDResponse class, so that the compiler knows how it is defined
 

--- a/building/README.md
+++ b/building/README.md
@@ -257,7 +257,8 @@ contains those packages, or less packages, then you are fine and you may continu
 
 > If you think a package is shown but should not be in the list because you are sure you have
 > installed it, it might just be that its version it's incompatible (this frequently happens with
-> `CMake`) or you are missing the "development" package for that component.
+> `CMake`) or you are missing the "development" package for that component. In this case, AliDoctor gives
+> an advice for the command you should enter to install the missing packages.
 
 
 ### Build and rebuild


### PR DESCRIPTION
Two examples on adding arguments to function calls in ROOT6 are added, as well as fixing some small typos.