### PR TITLE
Fix pip3 for alidock and subscription

### DIFF
--- a/building/alidock.md
+++ b/building/alidock.md
@@ -130,7 +130,7 @@ export PATH="$PYTHONUSERBASE/bin:$PATH"
 Open a new shell (or terminal window/tab) and install it with:
 
 ```bash
-pip3 install --upgrade alidock
+pip3 install --upgrade --user alidock
 ```
 
 {% callout "Upgrade alidock when it says so!" %}

--- a/start/README.md
+++ b/start/README.md
@@ -57,9 +57,9 @@ there are two mailing lists:
 * General questions on analysis, build problems, etc.: <alice-project-analysis-task-force@cern.ch>
 * Problems with jobs submission, certificates, trains: <alice-analysis-operations@cern.ch>
 
-The addresses above are [CERN egroups](http://egroups.cern.ch). You need a CERN account in order to
-use them. You can subscribe to the list by kindly asking Latchezar Betev via
-email: <Latchezar.Betev@cern.ch>
+You can self-subscribe to them if you are an [ALICE member](#are-you-a-registered-alice-member). Go
+to the [CERN egroups](http://egroups.cern.ch) page, search for the group name, click on it and then
+you will be presented with an option to subscribe. You can unsubscribe using the same procedure.
 
 Support for Run 3 does not rely on mailing lists. We are using [Discourse](https://discourse.org):
 


### PR DESCRIPTION
* Add missing `--user` to `pip3 install` where appropriate
* Fix the subscription policy for the mailing lists