### PR TITLE
Add missing "install"

### DIFF
--- a/building/build.md
+++ b/building/build.md
@@ -227,7 +227,7 @@ later](#run-a-single-command-in-the-environment)):
 
 ```bash
 cd $ALIBUILD_WORK_DIR/BUILD/AliPhysics-latest/AliPhysics
-alienv setenv GCC-Toolchain/latest -c make -j <num-parallel-jobs>
+alienv setenv GCC-Toolchain/latest -c make -j <num-parallel-jobs> install
 ```
 
 Replace `<num-parallel-jobs>` with a sensible number (_e.g._ slightly more than the actual number of


### PR DESCRIPTION
I was helping a new member of our group, and noticed that `install` was missing from the line to rebuild AliPhysics.

I still haven't switched to alidock, so it's possible that I've missed some underlying reason why this isn't required (if so, please close and disregard), but otherwise, I think calling `make install` is required - it appear to fix the issue in our case