### PR TITLE
Remove boost from the pre-req on mac

### DIFF
--- a/building/prereq-macos.md
+++ b/building/prereq-macos.md
@@ -119,7 +119,7 @@ It is now time to install a bunch of required packages. Copy and paste this to y
 (warning: long line):
 
 ```bash
-brew install autoconf automake boost coreutils gettext gmp hub isl libmpc libtool m4 modules mpfr openssl pkg-config readline modules xz libpng perl
+brew install autoconf automake coreutils gettext gmp hub isl libmpc libtool m4 modules mpfr openssl pkg-config readline modules xz libpng perl
 ```
 
 If you have just upgraded your Xcode or macOS, you should run `brew reinstall` instead, in order to


### PR DESCRIPTION
Since anyway a specific version is required by alidist and sometimes brew's boost breaks aliBuild's, let's remove boost from the requirements.