### PR TITLE
Remove preferred building option for ALICE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ book.pdf
 /env.sh
 /building/Dockerfile_*
 /secrets.txt
+.idea/

--- a/building/README.md
+++ b/building/README.md
@@ -1,20 +1,12 @@
 Build ALICE software
 ====================
 
-The ALICE experiment currently comprises two frameworks:
+There are two ways of building ALICE software on your computer:
 
-* [AliRoot](https://github.com/alisw/AliRoot)/[AliPhysics](https://github.com/alisw/AliPhysics) for
-  LHC Run 1 and Run 2
-* [O2](https://github.com/AliceO2Group/AliceO2) for Run 3 software on
+* [Install ALICE software with alidock](alidock.md) 
+This option provide users with a consistent environment based on containers. On non-CC7 systems you will benefit from precompiled binaries which will make you save plenty of time. This method works on any modern Linux distribution and macOS but does not offer support for GUIs. 
+_This is the recommended method for physicists doing analysis._
 
-**The preferred way to get ALICE software built on your computer is by means of
-[alidock](https://github.com/alidock/alidock).** We provide users with a consistent environment
-based on containers. By using alidock, you will benefit from precompiled binaries which will make
-you save plenty of time. This method works on any modern Linux distribution and macOS.
-
-* [🐳 Install ALICE software with alidock](alidock.md)
-
-We also have instructions for installing your software without using our controlled environment. We
-do not recommend you to follow this path, though, since alidock has better support.
-
-* [🐌 Install ALICE software manually](custom.md)
+* [Install ALICE software directly with alibuild](custom.md)
+This option provides users with a way to build the ALICE software directly on their system. On CC7 you will benefit from precompiled binaries which will make you save plenty of time. This method works on any modern Linux distribution and macOS. GUIs are supported. 
+_This is the recommended method for O2 development (including detectors)._

--- a/building/README.md
+++ b/building/README.md
@@ -3,10 +3,10 @@ Build ALICE software
 
 There are two ways of building ALICE software on your computer:
 
-* [Install ALICE software with alidock](alidock.md) 
-This option provide users with a consistent environment based on containers. On non-CC7 systems you will benefit from precompiled binaries which will make you save plenty of time. This method works on any modern Linux distribution and macOS but does not offer support for GUIs. 
+* [Install ALICE software with alidock](alidock.md)  
+This option provide users with a consistent environment based on containers. On non-CC7 systems you will benefit from precompiled binaries which will make you save plenty of time. This method works on any modern Linux distribution and macOS but does not offer support for GUIs.  
 _This is the recommended method for physicists doing analysis._
 
-* [Install ALICE software directly with alibuild](custom.md)
-This option provides users with a way to build the ALICE software directly on their system. On CC7 you will benefit from precompiled binaries which will make you save plenty of time. This method works on any modern Linux distribution and macOS. GUIs are supported. 
+* [Install ALICE software directly with alibuild](custom.md)  
+This option provides users with a way to build the ALICE software directly on their system. On CC7 you will benefit from precompiled binaries which will make you save plenty of time. This method works on any modern Linux distribution and macOS. GUIs are supported.  
 _This is the recommended method for O2 development (including detectors)._


### PR DESCRIPTION
As discussed in the WP3, remove the strong wording towards alidock. For O2 developers, including the detectors people, it is usually better to use alibuild on their system. In particular, it allows to use the DPL gui.

I took the opportunity to simplify the page. 

If it seems too confusing, I would propose to have a simple table assessing which features each option has.