### PR TITLE
Adding GFLW as dependency for Ubuntu 18.04 and CentOS 7

### DIFF
--- a/building/prereq-centos7.md
+++ b/building/prereq-centos7.md
@@ -12,7 +12,7 @@ With root permissions, i.e. `sudo` or as `root` install the prerequisites using:
 
 <!-- Dockerfile RUN_INLINE -->
 ```bash
-yum install -y git mysql-devel curl curl-devel bzip2 bzip2-devel unzip autoconf automake texinfo gettext gettext-devel libtool freetype freetype-devel libpng libpng-devel sqlite sqlite-devel ncurses-devel mesa-libGLU-devel libX11-devel libXpm-devel libXext-devel libXft-devel libxml2 libxml2-devel motif motif-devel kernel-devel pciutils-devel kmod-devel bison flex perl-ExtUtils-Embed environment-modules tk-devel
+yum install -y git mysql-devel curl curl-devel bzip2 bzip2-devel unzip autoconf automake texinfo gettext gettext-devel libtool freetype freetype-devel libpng libpng-devel sqlite sqlite-devel ncurses-devel mesa-libGLU-devel libX11-devel libXpm-devel libXext-devel libXft-devel libxml2 libxml2-devel motif motif-devel kernel-devel pciutils-devel kmod-devel bison flex perl-ExtUtils-Embed environment-modules tk-devel glfw-devel
 ```
 
 ## Python and pip
@@ -20,7 +20,7 @@ AliBuild, our build tool, is installed via the python Package manager `pip`.
 In case  
 ```bash
 pip3 show pip
-``` 
+```
 returns `command not found` or similar, install `pip` with root permissions, i.e. `sudo` or as `root`:
 <!-- Dockerfile RUN_INLINE -->
 ```bash
@@ -46,11 +46,11 @@ Then, still with `root` permissions install compilers and developer tools via:
 ```bash
 yum install -y devtoolset-7
 ```
-By design these tools do not replace the standard tools shipped by the system and have to be enabled explicitly for every new shell session you open: 
+By design these tools do not replace the standard tools shipped by the system and have to be enabled explicitly for every new shell session you open:
 ```bash
 source scl_source enable devtoolset-7
 ```
-If desired so, the above line can be added to your `~/.bashrc` or `~/.bash_profile`, so that tools shipped via devtoolset are automatically available in every shell. However beware that in some special cases that this might have undesired side effects. 
+If desired so, the above line can be added to your `~/.bashrc` or `~/.bash_profile`, so that tools shipped via devtoolset are automatically available in every shell. However beware that in some special cases that this might have undesired side effects.
 
 You can check if you are running the correct version of GCC with:
 

--- a/building/prereq-ubuntu.md
+++ b/building/prereq-ubuntu.md
@@ -26,7 +26,7 @@ sudo apt update -y
 ### Ubuntu 16.04:
 With root permissions, _i.e._ `sudo` install the following packages:
 ```bash
-sudo apt install -y curl libcurl4-openssl-dev build-essential gfortran cmake libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev libyaml-cpp-dev rsync lsb-release unzip environment-modules
+sudo apt install -y curl libcurl4-openssl-dev build-essential gfortran cmake libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev libyaml-cpp-dev rsync lsb-release unzip environment-modules libglfw3-dev
 ```
 
 ### Ubuntu 18.04:
@@ -34,7 +34,7 @@ With root permissions, _i.e._ `sudo` install the following packages:
 
 <!-- Dockerfile RUN_INLINE -->
 ```bash
-sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran cmake libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev libyaml-cpp-dev rsync lsb-release unzip environment-modules libglfw3-dev libglfw3
+sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran cmake libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev libyaml-cpp-dev rsync lsb-release unzip environment-modules libglfw3-dev
 ```
 
 ## Python and pip

--- a/building/prereq-ubuntu.md
+++ b/building/prereq-ubuntu.md
@@ -29,12 +29,12 @@ With root permissions, _i.e._ `sudo` install the following packages:
 sudo apt install -y curl libcurl4-openssl-dev build-essential gfortran cmake libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev libyaml-cpp-dev rsync lsb-release unzip environment-modules
 ```
 
-### Ubuntu 18.04: 
+### Ubuntu 18.04:
 With root permissions, _i.e._ `sudo` install the following packages:
 
 <!-- Dockerfile RUN_INLINE -->
 ```bash
-sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran cmake libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev libyaml-cpp-dev rsync lsb-release unzip environment-modules
+sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran cmake libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev libyaml-cpp-dev rsync lsb-release unzip environment-modules libglfw3-dev libglfw3
 ```
 
 ## Python and pip
@@ -42,7 +42,7 @@ AliBuild, our build tool, is installed via the python Package manager `pip`.
 In case  
 ```bash
 pip show pip
-``` 
+```
 returns `command not found` or similar, install `pip` with `root` permissions, i.e. `sudo` or as `root`:
 
 <!-- Dockerfile RUN_INLINE -->


### PR DESCRIPTION
* Adding dependencies for Ubuntu 18.04: libglfw3-dev libglfw3
* Adding dependecy for CentOS 7: glfw-devel

See https://alice-talk.web.cern.ch/t/building-o2-fails-in-debuggui/444
