### PR TITLE
Add information about JAliEn and alien.py

### DIFF
--- a/analysis/MC.md
+++ b/analysis/MC.md
@@ -8,11 +8,24 @@ The main reason for analyzing MC events is that it enables the analyzer to calcu
 
 First, we have to download the MC data. Since we downloaded Pb-Pb data from the period LHC15o with run number 246757, we will download an AOD file from the same run of a MC that is anchored to this period; namely LHC16g1.
 
-```cpp
-aliensh
+
+
+```bash
+alien.py
 cd /alice/sim/2016/LHC16g1/246757/AOD198/0002/
-cp AliAOD.root file:.
+cp alien://AliAOD.root file://AliAOD.root
 ```
+
+{% callout "AliEn legacy shell" %}
+In case you are using AliEn legacy software please use _aliensh_ instead of _alien.py_.
+The syntax in aliensh is slightly different, you should use `alien:` and `file:` prefix. For example:
+
+```
+aliensh
+cp alien:AliAOD.root file:AliAOD.root
+```
+{% endcallout %}
+
 It might be useful to rename the file to AliAOD_MC.root to avoid confusion later on. If you do so, of course you have to change the name of the input data file that you specify in runAnalysis.C.
 
 Now if we don't do anything else and run the analysis, the MC data will be processed as if it was data, and should produce a similar output when compared to real data. But of course we want to and can do more!

--- a/analysis/grid.md
+++ b/analysis/grid.md
@@ -21,12 +21,12 @@ Note that we will first **test** if our code is actually 'grid compatible', by *
 
 ## Running a Grid test
 
+{% callout "AliEn-ROOT-Legacy tokens " %}
+In case you are using AliEn-ROOT-Legacy, for instance with ROOT5, then you should first create an access token using command _alien-token-init_.
+{% endcallout %}
 
-If you think everything is OK, initialize a token 
-```
-alien-token-init <username>
-```
-and run the Grid test by simply launching the runAnalysis macro
+
+If you think everything is OK, and run the Grid test by simply launching the runAnalysis macro
 ```
 aliroot runAnalysis.C
 ```

--- a/analysis/rungrid.md
+++ b/analysis/rungrid.md
@@ -15,7 +15,7 @@ In order to run your analysis transparently either on your local computer or on 
 * Using all existing types of input data to be processed (root files, raw AliEn collections or XML collections) detecting their type automatically;
 * Generate XML collections corresponding to requested runs and/or data patterns;
 * Automatically detect presence of tags in input data and allow using tag-based cuts in a very simple way;
-* Automatically connect to AliEn (generate a token if needed) - still requires sourcing the environment file produced by alien.token-init;
+* Automatically connect to AliEn (generate a token if needed)
 * Generate automatically: JDL, analysis macro to be run in grid, execution and validation scripts according a simple to understand user-driven configuration; 
 * Copy all needed files in user's AliEn space and submit the job automatically;
 * Start an alien shell to allow inspecting the job status;
@@ -107,8 +107,8 @@ When you run an analysis in test mode, a Grid environment is simulated locally f
 
 Once your analysis test is finished, and you are convinced that your analysis output looks sane, you can submit your analysis to the Grid nodes. To do this, simply look at at the code snippet above, and assume that the variable `gridTest` is set to kFALSE. 
 
-{% callout "Do not forget your token!" %}
-Only ALICE members with a valid registration can submit jobs to the Grid and access the ALICE data. To identify yourself as an ALICE member, you will have to make sure that you have a valid token prior to launching your Grid jobs, be it in full or in test mode. To obtain a token, do
+{% callout "Create AliEn legacy token!" %}
+Only ALICE members with a valid registration can submit jobs to the Grid and access the ALICE data. To identify yourself as an ALICE member, you will have to make sure that you have a valid token prior to launching your Grid jobs, be it in full or in test mode. If you are using AliEn legacy, then you need to obtain a token manually. If you are using JAliEn, then the token will be obtained automatically.
 ```
 $ alien-token-init <username>
 ```

--- a/analysis/setup.md
+++ b/analysis/setup.md
@@ -184,5 +184,9 @@ cp AliAOD.root file:.
 
 Note the syntax of the copy command, here we tell to copy the _remote_ file AliAOD.root to our own laptop by specifying _file:._ . 
 
+{% callout "JAliEn and AliEn shell documentation" %}
+You can find more information about the alien.py shell at [jalien.docs.cern.ch](https://jalien.docs.cern.ch). Reference documentation for the legacy AliEn shell is available at [alien.web.cern.ch](https://alien.web.cern.ch/content/documentation/howto/user/catalogue).
+{% endcallout %}
+
 ## Trouble ?
 If for some reason this does not work for you - no fear. You can ask a colleague to provide a file for you, or send a mail to our mailing lists  if you are having trouble with access.

--- a/analysis/setup.md
+++ b/analysis/setup.md
@@ -177,7 +177,6 @@ Move to the directory where the data we are looking for is stored
 ```
 cd /alice/data/2015/LHC15o/000246757/pass1/AOD/002/
 ```
-NOTE: this example needs to be updated
 and copy the AliAOD.root file that is inside this folder to your ** local ** hard drive by doing
 ```
 cp AliAOD.root file:.

--- a/analysis/setup.md
+++ b/analysis/setup.md
@@ -44,7 +44,7 @@ Remember, that for now, the name ‘AliAnalysisTaskMyTask’ doesn’t sound so 
 To run your own analysis task, you will also need to download a file that contains reconstructed collisions. This input file is called **AliAOD.root**, short for Analysis Object Data. In the following steps, will assume that we are looking at Pb-Pb data that was taken in 2015. You can also choose to run on data from a different period or collision system.  
 
 ## Source your environment
-We will get the data form the ALICE file catalogue. To access the file catalogue, you will need to use AliEn-Runtime and have a valid Grid certificate. This means that, at this point, we will assume that you have built all the ALICE software (see [our build manual for that](https://alice-doc.github.io/alice-analysis-tutorial/building/) ).
+We will get the data form the ALICE file catalogue. To access the file catalogue, you will need to use xjalienfs or xalienfs packages and have a valid Grid certificate. This means that, at this point, we will assume that you have built all the ALICE software (see [our build manual for that](https://alice-doc.github.io/alice-analysis-tutorial/building/) ).
 
 
 Load your ALICE environment as [explained here](https://alice-doc.github.io/alice-analysis-tutorial/building/#use-the-software-you-have-built), e.g. by doing
@@ -56,26 +56,39 @@ alienv enter AliPhysics::latest
 You should see which module files are currently loaded, e.g.
 
 ```
-  1) BASE/1.0
-  2) GCC-Toolchain/v6.2.0-alice1-1
-  3) AliEn-Runtime/v2-19-le-1
-  4) GSL/v1.16-1
-  5) Python-modules/1.0-1
-  6) ROOT/v6-10-06+git_c54db1c10b-1
-  7) boost/v1.59.0-1
-  8) cgal/v4.6.3-1
-  9) fastjet/v3.2.1_1.024-alice1-1
- 10) Vc/1.3.2-1
- 11) AliRoot/0742e9dc6e12c74634a1e353ab00ceba45335401_ROOT6-1
- 12) AliPhysics/latest
+ 1) BASE/1.0
+ 2) AliEn-Runtime/v2-19-le-49
+ 3) OpenSSL/v1.0.2o-9
+ 4) Python-modules/1.0-11
+ 5) XRootD/v4.11.1-14
+ 6) ROOT/v6-18-04-alice2-1
+ 7) boost/v1.70.0-6
+ 8) cgal/4.6.3-5
+ 9) fastjet/v3.2.1_1.024-alice3-21
+10) Vc/1.4.1-5
+11) xjalienfs/1.0.6-2
+12) JAliEn-ROOT/0.6.0-2
+13) AliRoot/master-1
+14) RooUnfold/V02-00-01-alice4-25
+15) treelite/a7a0839-2
+16) KFParticle/alice-v1.1-1-9
+17) AliPhysics/latest
+12) AliPhysics/latest
 Use alienv list to list loaded modules. Use exit to exit this environment.
 ```
 
-The module Alien-Runtime is now available, which is what we will use to get our data. 
+The module xjalienfs is now available, which is what we will use to get our data. 
 
-## Get a valid token
+## Get a valid token (optional)
 
-The ALICE file catalogue is only accessible if you are an ALICE member. To authenticate yourself, you will need to obtain a _token_
+{% callout "JAliEn tokens" %}
+You can skip this step if you are using JAliEn. JAliEn clients create the token automatically, but you can still run _alien-token-init_ to refresh it manually.
+{% endcallout %}
+
+The ALICE file catalogue is only accessible if you are an ALICE member. 
+
+If you are using AliEn-ROOT-Legacy or ROOT5, then you first need to authenticate yourself and obtain a _token_
+
 ```
 alien-token-init <username>
 ``` 
@@ -116,16 +129,46 @@ Creating token ..................................... Done
 Your token is valid until: Wed Nov  1 13:21:18 2017
 ```
 
-Once you have obtained a valid token, enter the alice environment shell by typing
+For comparison, here is the output from the JAlien _alien-token-init_
+
 ```
-aliensh
+[AliPhysics/latest] ~ > alien-token-init
+INFO: JAliEn client automatically creates tokens, alien-token-init is deprecated
+DN >>> /C=ch/O=AliEn2/CN=Users/CN=nhardi/OU=nhardi
+ISSUER >>> /C=ch/O=AliEn/CN=AliEn CA
+BEGIN >>> 2020-03-26 10:06:05
+EXPIRE >>> 2020-04-26 08:16:48
 ```
+
+## Open the AliEn shell
+
+You can now enter the alice environment shell by typing
+
+
+```
+alien.py
+```
+
 Once you type this command, a the alice environment shell is loaded, and you should see
+
+```
+[AliPhysics/latest] ~ > alien.py
+Welcome to the ALICE GRID
+support mail: adrian.sevcenco@cern.ch
+
+AliEn[nhardi]:/alice/cern.ch/user/n/nhardi/ >
+
+```
+
+
+The AliEn legacy shell _aliensh_ and JAliEn shell _alien.py_ are very similar. The command prompt for aliensh shell looks like this:
+
 ```
 [AliPhysics/latest] ~/sw $> aliensh
  [ aliensh 1.0.140x (C) ARDA/Alice: Andreas.Joachim.Peters@cern.ch/Derek.Feichtinger@cern.ch]
 aliensh:[alice] [1] /alice/cern.ch/user/r/rbertens/ >
 ```
+
 This shell works a lot like a normal unix shell, but it is not - not all commands that you expect to find are defined. 
 
 
@@ -134,6 +177,7 @@ Move to the directory where the data we are looking for is stored
 ```
 cd /alice/data/2015/LHC15o/000246757/pass1/AOD/002/
 ```
+NOTE: this example needs to be updated
 and copy the AliAOD.root file that is inside this folder to your ** local ** hard drive by doing
 ```
 cp AliAOD.root file:.

--- a/start/cert.md
+++ b/start/cert.md
@@ -155,3 +155,8 @@ either `alienv` or the `alien-token-*` commands available in case you have never
 
 The `alien-token-init` command will ask you for a password. This is the last password you have used
 when you have converted your `.p12` certificate into two `.pem` files.
+
+{% callout "Creating JAliEn and AliEn tokens" %}
+Note that the new JAliEn Grid clients automatically create tokens, while AliEn-ROOT-Legacy (ROOT5) requires running _alien-token-init_ manually.
+There is _alien-token-init_ for JAliEn, and you can use it to test your credentials or (re)create tokens manually.
+{% endcallout %}


### PR DESCRIPTION
Adding JAliEn and alien.py related updates. Mostly notes that alien-token-init is now optional, and switch from aliensh to alien.py.