### PR TITLE
Build tutorial - update from pip to pip3 ?

### DIFF
--- a/building/custom.md
+++ b/building/custom.md
@@ -71,7 +71,7 @@ it will be just more difficult for you to get support for it.
 Install or upgrade [aliBuild](https://pypi.python.org/pypi/alibuild/) with `pip`:
 
 ```bash
-sudo pip install alibuild --upgrade
+sudo pip3 install alibuild --upgrade
 ```
 
 Now add the two following lines to your `~/.bashrc` or `~/.bash_profile` (depending on your


### PR DESCRIPTION
Maybe such a change is needed (pip -> pip3).
At least seems necessary under Ubuntu 18.04 LTS.