### PR TITLE
Add libtbb-dev, required for building DebugGUI on Ubuntu 20

### DIFF
--- a/building/prereq-ubuntu.md
+++ b/building/prereq-ubuntu.md
@@ -35,7 +35,7 @@ With root permissions, _i.e._ `sudo`, install the following packages:
 
 <!-- Dockerfile RUN_INLINE -->
 ```bash
-sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran cmake libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev libyaml-cpp-dev rsync lsb-release unzip environment-modules libglfw3-dev
+sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran cmake libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev libyaml-cpp-dev rsync lsb-release unzip environment-modules libglfw3-dev libtbb-dev
 ```
 
 ## Python and pip


### PR DESCRIPTION
On Ubuntu 20.04 the compilation of DebugGUI fails without the package with the following error message:

Resolving dependencies of ../../../server/TracyWorker.cpp
In file included from /usr/include/c++/9/pstl/parallel_backend.h:14,
                 from /usr/include/c++/9/pstl/algorithm_impl.h:25,
                 from /usr/include/c++/9/pstl/glue_execution_defs.h:52,
                 from /usr/include/c++/9/execution:32,
                 from ../../../server/TracySort.hpp:7,
                 from ../../../server/TracyWorker.cpp:27:
/usr/include/c++/9/pstl/parallel_backend_tbb.h:28:2: error: #error Intel(R) Threading Building Blocks 2018 is required; older versions are not supported.
   28 | #error Intel(R) Threading Building Blocks 2018 is required; older versions are not supported.
      |  ^~~~~

Installing libtbb-dev solved the issue for me. Otherwise a fix described in https://alice.its.cern.ch/jira/browse/O2-1631 is required (at least this was the case for me).

Cheers,
Ole