### PR TITLE
O2-1802 [Ubuntu] instructions for 20.04, removed 16.04

### DIFF
--- a/building/prereq-ubuntu.md
+++ b/building/prereq-ubuntu.md
@@ -13,7 +13,6 @@ ALICE software on Ubuntu is supported on a best effort basis. There is no guaran
 
 * Ubuntu 20.04 LTS
 * Ubuntu 18.04 LTS
-* Ubuntu 16.04 LTS
 
 ## Install required system packages
 
@@ -24,18 +23,12 @@ With root permissions, _i.e._ `sudo`, update your package sources:
 ```bash
 sudo apt update -y
 ```
-### Ubuntu 16.04:
-With root permissions, _i.e._ `sudo`, install the following packages:
-```bash
-sudo apt install -y curl libcurl4-openssl-dev build-essential gfortran cmake libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev libyaml-cpp-dev rsync lsb-release unzip environment-modules libglfw3-dev
-```
 
-### Ubuntu 18.04, 20.04:
 With root permissions, _i.e._ `sudo`, install the following packages:
 
 <!-- Dockerfile RUN_INLINE -->
 ```bash
-sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran cmake libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev libyaml-cpp-dev rsync lsb-release unzip environment-modules libglfw3-dev libtbb-dev
+sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev rsync lsb-release unzip environment-modules libglfw3-dev libtbb-dev python3-venv libncurses-dev
 ```
 
 ## Python and pip


### PR DESCRIPTION
I propose a cleanup for the Ubuntu prerequisites page: 

* Remove `Ubuntu 16.04` instructions as they don't work: `scipy` needs `python 3.6` but `16.04` comes with `python 3.5.4` and thus `python-modules` fail. So it's better to remove the instructions. If someone wants to use `16.04` they can figure out themselves.

* Updated instructions for `Ubuntu 18.04` and `20.04`:  removed `cmake` as we always use a more recent version and `libyaml-cpp-dev` as it fails to build with `20.04`. Add  `libtbb-dev`,  `python3-venv` and `libncurses-dev` to compile with `20.04`. Tested both `18.04` and `20.04` in docker containers to simulate a fresh install. 
