### PR TITLE
Remove duplicate in ubuntu prerequisites

### DIFF
--- a/building/prereq-ubuntu.md
+++ b/building/prereq-ubuntu.md
@@ -28,7 +28,7 @@ With root permissions, _i.e._ `sudo`, install the following packages:
 
 <!-- Dockerfile RUN_INLINE -->
 ```bash
-sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev rsync lsb-release unzip environment-modules libglfw3-dev libtbb-dev python3-venv libncurses-dev
+sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev rsync lsb-release environment-modules libglfw3-dev libtbb-dev python3-venv libncurses-dev
 ```
 
 ## Python and pip


### PR DESCRIPTION
Package `unzip` is twice in the list. Doesn't hurt using apt, but puppet complains when I want to use this list so I removed the duplicate.