### PR TITLE
Bump GH-Pages deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
 
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@3.5.9
+        uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.


### PR DESCRIPTION
Need to bump action version because of deprecation of `set-env` _et similia_ in GHA runners.
For instance, latest PR: https://github.com/alice-doc/alice-analysis-tutorial/pull/115 failed because of that.

A bump to v3.7.1 should fix it, see: https://github.com/JamesIves/github-pages-deploy-action/issues/500