### PR TITLE
Drop the need to disable SIP

### DIFF
--- a/building/prereq-macos.md
+++ b/building/prereq-macos.md
@@ -24,25 +24,6 @@ sudo xcode-select --install
 ```bash
 sudo xcodebuild -license
 ```
-## Disable System Integrity Protection (SIP)
-System Integrity Protection was introduced by Apple to Mac OSX since El Capitan and is meant to harden the system against malicious software. More details are available in [Apple's knowledge base](https://support.apple.com/en-us/HT204899).
-Unfortunately, some of the measures taken by SIP (in particular not propagating `LD_LIBRARY_PATH`) will cause ROOT to not find dynamic libraries. We therefore have to switch off SIP.
-
-* Reboot your Mac in _Recovery Mode_. by holding `Command-R` at startup until the Apple logo appears.
-* Open a Terminal: (`Utilities>Terminal`).
-* Disable SIP by executing
-```csrutil disable``` 
-* Restart your machine.
-* After the reboot, open a terminal (`Applicaions>Utilities>Terminal`) and check if 
-```bash
-csrutil status
-```
-returns `System Integrity Protection status: disabled.`
-
-The process can be reverted by following the above steps executing  
-```csrutil enable```
-
-The process is also documented in [Apple's developer documentation](https://developer.apple.com/library/archive/documentation/Security/Conceptual/System_Integrity_Protection_Guide/ConfiguringSystemIntegrityProtection/ConfiguringSystemIntegrityProtection.html)
 
 ## Get Homebrew
 


### PR DESCRIPTION
We have everything in place to support SIP enabled installations. If it does not work, we should fix it.