### PR TITLE
Use cmake for rebuilds, just as in the aliphysics.sh recipe

### DIFF
--- a/building/build.md
+++ b/building/build.md
@@ -217,7 +217,7 @@ later](#run-a-single-command-in-the-environment)):
 
 ```bash
 cd $ALIBUILD_WORK_DIR/BUILD/AliPhysics-latest/AliPhysics
-alienv setenv GCC-Toolchain/latest -c make -j <num-parallel-jobs> install
+alienv setenv GCC-Toolchain/latest -c cmake --build . -- -j <num-parallel-jobs> install
 ```
 
 Replace `<num-parallel-jobs>` with a sensible number (_e.g._ slightly more than the actual number of


### PR DESCRIPTION
@ktf for consistency I thought we could change the AliPhysics documentation so that for rebuilds the same build command is used as in the alidist AliPhysics recipe: `cmake --build . -- -j <num-parallel-jobs> install` instead of `make -j <num-parallel-jobs> install`. That would automatically use either make or ninja. I tried it only on Ubuntu, but I think it should work on the other systems as well.