### PR TITLE
Simplify build instructions

### DIFF
--- a/building/custom.md
+++ b/building/custom.md
@@ -51,6 +51,7 @@ packages to install and configurations to perform.
 **Primary supported platform:**
 
 * [CentOS 7](prereq-centos7.md)
+* [CentOS 8](prereq-centos8.md)
 
 **Platforms supported on a best-effort basis:**
 
@@ -66,15 +67,10 @@ packages to install and configurations to perform.
 If your operating system is _not_ in any list, it does not mean our software won't work on it;
 it will be just more difficult for you to get support for it.
 
-## Get or upgrade aliBuild
+## Configure aliBuild
 
-Install or upgrade [aliBuild](https://pypi.python.org/pypi/alibuild/) with `pip`:
-
-```bash
-sudo pip3 install alibuild --upgrade
-```
-
-Now add the two following lines to your `~/.bashrc` or `~/.bash_profile` (depending on your
+After you are done installing alibuild you need to configure it by adding two
+following lines to your `~/.bashrc` or `~/.bash_profile` (depending on your
 configuration):
 
 ```bash
@@ -124,7 +120,6 @@ Verify you have `aliBuild` in your path:
 ```bash
 type aliBuild
 ```
-
 
 ### I need a special version of aliBuild
 

--- a/building/prereq-centos7.md
+++ b/building/prereq-centos7.md
@@ -1,16 +1,12 @@
 aliBuild Prerequisites for CentOS 7
 ===================================
 
-<!-- Dockerfile UPLOAD_NAME alisw/o2-cc7 -->
-<!-- Dockerfile FROM centos:7 -->
-<!-- Dockerfile RUN rpmdb --rebuilddb && yum clean all -->
 For ALICE O2, CERN CentOS 7 (CC7)is the [officialy supported target platform](https://indico.cern.ch/event/642232/#3-wp3-common-tools-and-softwar). Since CC7 is CentOS 7 with additional CERN packages, instructions apply to vanilla CentOS 7 as well.
 
 ## Install or Upgrade the Required Packages
 
 With root permissions, i.e. `sudo` or as `root` install the prerequisites using:
 
-<!-- Dockerfile RUN_INLINE -->
 ```bash
 cat << EOF > /etc/yum.repos.d/alice-system-deps.repo
 [alice-system-deps]
@@ -23,13 +19,5 @@ yum update -y
 yum install -y alice-o2-full-deps alibuild
 ```
 
-You are now ready for [installing aliBuild and start building ALICE
-software](README.md#get-or-upgrade-alibuild)
+You are now ready to [start building ALICE software](README.md#get-or-upgrade-alibuild)
 
-<!-- Dockerfile RUN yum install -y vim-enhanced emacs-nox -->
-<!-- Dockerfile RUN rpmdb --rebuilddb && yum clean all -->
-<!-- Dockerfile RUN echo "source scl_source enable devtoolset-7" >> /etc/profile -->
-<!-- Dockerfile RUN echo "source scl_source enable devtoolset-7" >> /etc/bashrc -->
-<!-- Dockerfile RUN pip install alibuild -->
-<!-- Dockerfile RUN mkdir /lustre /cvmfs -->
-<!-- Dockerfile ENTRYPOINT ["/bin/bash"] -->

--- a/building/prereq-centos8.md
+++ b/building/prereq-centos8.md
@@ -1,9 +1,6 @@
 aliBuild Prerequisites for CentOS 8
 ===================================
 
-<!-- Dockerfile UPLOAD_NAME alisw/o2-cc7 -->
-<!-- Dockerfile FROM centos:7 -->
-<!-- Dockerfile RUN rpmdb --rebuilddb && yum clean all -->
 For ALICE O2, CentOS 8 (CC8) is not yet an [officialy supported target platform](https://indico.cern.ch/event/642232/#3-wp3-common-tools-and-softwar).
 
 
@@ -28,29 +25,7 @@ enabled=1
 gpgcheck=0
 EOF
 yum update -y
-yum install -y alice-o2-full-deps
+yum install -y alice-o2-full-deps alibuild
 ```
 
-## Python and pip
-AliBuild, our build tool, is installed via the python Package manager `pip`.
-In case  
-```bash
-pip3 show pip
-```
-returns `command not found` or similar, install `pip` with root permissions, i.e. `sudo` or as `root`:
-<!-- Dockerfile RUN_INLINE -->
-```bash
-yum install -y python3-pip
-pip3 install --upgrade pip
-```
-
-You are now ready for [installing aliBuild and start building ALICE
-software](README.md#get-or-upgrade-alibuild)
-
-<!-- Dockerfile RUN yum install -y vim-enhanced emacs-nox -->
-<!-- Dockerfile RUN rpmdb --rebuilddb && yum clean all -->
-<!-- Dockerfile RUN echo "source scl_source enable devtoolset-7" >> /etc/profile -->
-<!-- Dockerfile RUN echo "source scl_source enable devtoolset-7" >> /etc/bashrc -->
-<!-- Dockerfile RUN pip install alibuild -->
-<!-- Dockerfile RUN mkdir /lustre /cvmfs -->
-<!-- Dockerfile ENTRYPOINT ["/bin/bash"] -->
+You are now ready to [start building ALICE software](README.md#get-or-upgrade-alibuild)

--- a/building/prereq-fedora.md
+++ b/building/prereq-fedora.md
@@ -27,6 +27,31 @@ dnf install -y python3-pip
 pip3 install --upgrade pip
 ```
 
+## Get or upgrade aliBuild
+
+Install or upgrade [aliBuild](https://pypi.python.org/pypi/alibuild/) with `pip`:
+
+```bash
+sudo pip3 install alibuild --upgrade
+```
+
+Now add the two following lines to your `~/.bashrc` or `~/.bash_profile` (depending on your
+configuration):
+
+```bash
+export ALIBUILD_WORK_DIR="$HOME/alice/sw"
+eval "`alienv shell-helper`"
+```
+
+The first line tells what directory is used as "build cache", the second line installs a "shell
+helper" that makes easier to run certain aliBuild-related commands.
+
+You need to close and reopen your terminal for the change to be effective. The directory
+`~/alice/sw` will be created the first time you run aliBuild.
+
+> Note that this directory tends to grow in size over time, and it is the one you need to remove in
+> case of cleanups.
+
 You are now ready for [installing aliBuild and start building ALICE
 software](README.md#get-or-upgrade-alibuild)
 

--- a/building/prereq-macos.md
+++ b/building/prereq-macos.md
@@ -38,9 +38,9 @@ brew doctor
 
 Note that Homebrew does not run as root. Do not prepend `sudo` to **any** of the following commands.
 
-* Install the prerequisites via:
+* Install the prerequisites and aliBuild via:
 ```bash
-brew install alisw/system-deps/o2-full-deps
+brew install alisw/system-deps/o2-full-deps alisw/system-deps/alibuild
 ```
 Various users have reported that this might terminate with an error. The solution oddly enough seems to be to execute the above command multiple times until brew does not complain anymore.
 * If you have just upgraded your Xcode or macOS, you should run `brew reinstall` instead, in order to force the reinstallation of already installed packages. You also might want to run `brew cleanup` at the end to free up some space.
@@ -51,19 +51,7 @@ export PATH="/usr/local/opt/gettext/bin:/usr/local/bin:$PATH"
 ```
 * Close Terminal and reopen it to apply changes.
 
-## Python
-In case you are using [Python from Anaconda](https://www.anaconda.com/) or Python from Homebrew
-then you have `pip` already. Check it by typing:
-```bash
-type pip3
-```
-If not present install with
-```bash
-sudo easy_install3.9 pip
-sudo pip3 install --upgrade pip
-```
-
-## (Optinal) Exclude your work directory from Spotlight
+## (Recommended) Exclude your work directory from Spotlight
 The mac search engine (Spotlight) will be indexing the build directory which can have severe effects on your system performance. To avoid that, you can exclude your working directory (we are assuming `~/alice` - create if not yet existing).
 Go to `(Apple) menu>System preferences>Spotlight`. In the `Privacy` tab, hit the `+` button. Now select the `~/alice` directory and confirm.
 

--- a/building/prereq-ubuntu.md
+++ b/building/prereq-ubuntu.md
@@ -1,14 +1,6 @@
 aliBuild prerequisites for Ubuntu
 =================================
 
-<!-- Dockerfile UPLOAD_NAME alisw/o2-ubuntu1804 -->
-<!-- Dockerfile FROM ubuntu:18.04 -->
-<!-- Dockerfile RUN export DEBIAN_FRONTEND=noninteractive -->
-<!-- Dockerfile RUN export DEBIAN_NONINTERACTIVE_SEEN=true -->
-<!-- Dockerfile RUN apt update -y -->
-<!-- Dockerfile RUN apt install -y sudo -->
-<!-- Dockerfile RUN echo -e "13\n33" | apt install -y tzdata -->
-<!-- Dockerfile RUN test `cat /etc/timezone` = Etc/UTC -->
 ALICE software on Ubuntu is supported on a best effort basis. There is no guarantee that software builds or runs correctly. Support requests might have low priority. We were able to successfully build on:
 
 * Ubuntu 18.04 LTS
@@ -19,37 +11,24 @@ ALICE software on Ubuntu is supported on a best effort basis. There is no guaran
 With root permissions, _i.e._ `sudo`, update your package sources:
 
 
-<!-- Dockerfile RUN_INLINE -->
 ```bash
 sudo apt update -y
 ```
 
 With root permissions, _i.e._ `sudo`, install the following packages:
 
-<!-- Dockerfile RUN_INLINE -->
 ```bash
-sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev rsync lsb-release environment-modules libglfw3-dev libtbb-dev python3-venv libncurses-dev
+sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev rsync lsb-release environment-modules libglfw3-dev libtbb-dev python3-venv libncurses-dev software-properties-common
 ```
 
-## Python and pip
-AliBuild, our build tool, is installed via the python Package manager `pip`.
-In case
-```bash
-pip show pip
-```
-returns `command not found` or similar, install `pip` with `root` permissions, i.e. `sudo` or as `root`:
+## Installing aliBuild
+AliBuild, our build tool, is installed as a standard ubuntu package, provided you enable the `alisw` [PPA](https://launchpad.net/ubuntu/+ppas) repository.
+This is done with:
 
-<!-- Dockerfile RUN_INLINE -->
 ```bash
-sudo apt install -y python3-pip
-sudo pip3 install --upgrade pip
+sudo add-apt-repository ppa:alisw/ppa  
+sudo apt update
+sudo apt install python3-alibuild
 ```
 
-You are now ready for [installing aliBuild and start building ALICE
-software](README.md#get-or-upgrade-alibuild)
-
-<!-- Dockerfile RUN apt install -y vim-nox emacs-nox -->
-<!-- Dockerfile RUN apt clean -y -->
-<!-- Dockerfile RUN pip install alibuild -->
-<!-- Dockerfile RUN mkdir /lustre /cvmfs -->
-<!-- Dockerfile ENTRYPOINT ["/bin/bash"] -->
+You are now ready to [start building ALICE software](README.md#get-or-upgrade-alibuild)


### PR DESCRIPTION
* Use distribution packages for aliBuild installation where available.
* Keep `pip` as a special case.