### PR TITLE
Make sure we have EPEL packages available

### DIFF
--- a/building/prereq-centos7.md
+++ b/building/prereq-centos7.md
@@ -16,7 +16,9 @@ enabled=1
 gpgcheck=0
 EOF
 yum update -y
-yum install -y alice-o2-full-deps alibuild
+yum install -y alice-o2-full-deps 
+yum update -y
+yum install -y alibuild
 ```
 
 You are now ready to [start building ALICE software](README.md#get-or-upgrade-alibuild)


### PR DESCRIPTION
This is required because if we do it in one go, EPEL and the required python3 packages required by aliBuild will not yet be available.