### PR TITLE
aliBuild prerequisite for Ubuntu - Need "python3-pydot"

### DIFF
--- a/building/prereq-ubuntu.md
+++ b/building/prereq-ubuntu.md
@@ -18,7 +18,7 @@ sudo apt update -y
 With root permissions, _i.e._ `sudo`, install the following packages:
 
 ```bash
-sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev rsync lsb-release environment-modules libglfw3-dev libtbb-dev python3-dev python3-venv python3-pip python3-pydot libncurses-dev software-properties-common
+sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev rsync lsb-release environment-modules libglfw3-dev libtbb-dev python3-dev python3-venv python3-pip graphviz libncurses-dev software-properties-common
 ```
 
 ## Installing aliBuild

--- a/building/prereq-ubuntu.md
+++ b/building/prereq-ubuntu.md
@@ -18,7 +18,7 @@ sudo apt update -y
 With root permissions, _i.e._ `sudo`, install the following packages:
 
 ```bash
-sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev rsync lsb-release environment-modules libglfw3-dev libtbb-dev python3-dev python3-venv python3-pip libncurses-dev software-properties-common
+sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev rsync lsb-release environment-modules libglfw3-dev libtbb-dev python3-dev python3-venv python3-pip python3-pydot libncurses-dev software-properties-common
 ```
 
 ## Installing aliBuild


### PR DESCRIPTION
For Ubuntu (at least my Kubuntu 20.04 LTS), I do not succeed to use "alibuild deps" to create graphs dependencies since quite some time.

6 amaire-sbgat92: AliceSuite >aliBuild deps YODA --defaults generators --outgraph test.pdf
ERROR: Error generating dependencies with dot: FileNotFoundError: [Errno 2] No such file or directory: 'dot'

I have just figured out that my system miss a needed system package : python3-pydot
I updated here the apt install command to include such an extra package