### PR TITLE
Ubuntu prerequisites

### DIFF
--- a/building/prereq-ubuntu.md
+++ b/building/prereq-ubuntu.md
@@ -19,7 +19,7 @@ sudo apt update -y
 With root permissions, _i.e._ `sudo`, install the following packages:
 
 ```bash
-sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev rsync lsb-release environment-modules libglfw3-dev libtbb-dev python3-dev python3-venv python3-pip graphviz libncurses-dev software-properties-common gtk-doc-tools
+sudo apt install -y curl libcurl4-gnutls-dev build-essential gfortran libmysqlclient-dev xorg-dev libglu1-mesa-dev libfftw3-dev libxml2-dev git unzip autoconf automake autopoint texinfo gettext libtool libtool-bin pkg-config bison flex libperl-dev libbz2-dev swig liblzma-dev libnanomsg-dev rsync lsb-release environment-modules libglfw3-dev libtbb-dev python3-dev python3-venv python3-pip graphviz libncurses-dev software-properties-common gtk-doc-tools libkmod-dev libpci-dev libmotif-dev
 ```
 
 ## Installing aliBuild


### PR DESCRIPTION
libpci and libkmod are necessary for Xdevel package
libmotif is required by motif
These all are ofcouse dev package.
But has to sudo apt update first, otherwise these sometimes remove a lot of packages including networkmanager