### PR TITLE
Document required development tools repo on Alma 9

### DIFF
--- a/building/prereq-alma9.md
+++ b/building/prereq-alma9.md
@@ -9,6 +9,7 @@ With root permissions, i.e. `sudo` or as `root` install the prerequisites using:
 ```bash
 dnf install -y epel-release dnf-plugins-core
 dnf update -y
+dnf config-manager --set-enabled crb
 dnf group install -y 'Development Tools'
 cat << EOF > /etc/yum.repos.d/alice-system-deps.repo
 [alice-system-deps]


### PR DESCRIPTION
Some required development tools aren't available in the default repos any more, so the "CRB" (formerly "PowerTools") repo needs to be enabled on Alma 9.